### PR TITLE
Add support for buildpacks with URL params. This is necessary for testin...

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -26,7 +26,7 @@ for BUILDPACK in $(cat $1/.buildpacks); do
   if [ "$url" != "" ]; then
     echo "=====> Downloading Buildpack: $url"
 
-    if [[ "$url" =~ \.tgz$ ]]; then
+    if [[ "$url" =~ \.tgz$ ]] || [[ "$url" =~ \.tgz\? ]]; then
       mkdir -p "$dir"
       curl -s "$url" | tar xvz -C "$dir" >/dev/null 2>&1
     else


### PR DESCRIPTION
_DON'T MERGE THIS YET_

This allows for tgz URL to include parameters. It's necessary for internal testing, but it could also be useful for those needing private buildpacks.
