### PR TITLE
Fix detect logic

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -30,6 +30,7 @@ for BUILDPACK in $(cat $1/.buildpacks); do
       mkdir -p "$dir"
       curl -s "$url" | tar xvz -C "$dir" >/dev/null 2>&1
     else
+      echo "=====> Cloning: $url"
       git clone $url $dir >/dev/null 2>&1
     fi
     cd $dir
@@ -41,6 +42,7 @@ for BUILDPACK in $(cat $1/.buildpacks); do
     # we'll get errors later if these are needed and don't exist
     chmod -f +x $dir/bin/{detect,compile,release} || true
 
+    echo "=====> Detecting framework..."
     framework=$($dir/bin/detect $1)
 
     if [ $? == 0 ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -30,7 +30,6 @@ for BUILDPACK in $(cat $1/.buildpacks); do
       mkdir -p "$dir"
       curl -s "$url" | tar xvz -C "$dir" >/dev/null 2>&1
     else
-      echo "=====> Cloning: $url"
       git clone $url $dir >/dev/null 2>&1
     fi
     cd $dir
@@ -42,8 +41,14 @@ for BUILDPACK in $(cat $1/.buildpacks); do
     # we'll get errors later if these are needed and don't exist
     chmod -f +x $dir/bin/{detect,compile,release} || true
 
-    echo "=====> Detecting framework..."
+    set +e
     framework=$($dir/bin/detect $1)
+    if [ $? != 0 ]; then
+      echo "Couldn't detect any framework for this buildpack. Exiting."
+      exit 1
+    fi
+    set -e
+
 
     if [ $? == 0 ]; then
       echo "=====> Detected Framework: $framework"
@@ -61,9 +66,6 @@ for BUILDPACK in $(cat $1/.buildpacks); do
       if [ -x $dir/bin/release ]; then
         $dir/bin/release $1 > $1/last_pack_release.out
       fi
-    else
-      echo "Couldn't detect any framework for this buildpack. Exiting."
-      exit 1
     fi
   fi
 done


### PR DESCRIPTION
The buildpack should tell you if no framework is detected. As currently working, it fails silently. 
