### PR TITLE
Deprecate this buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,25 @@
 # Heroku buildpack: multi
 
-This is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) that
-allows one to multiple other buildpacks in a single deploy process. This helps support:
+This buildpack has been deprecated, as the associated functionality exists natively on the Heroku platform. Please refer to https://devcenter.heroku.com/articles/buildpacks for documentation.
 
-1. Running multiple language buildpacks such as JS for assets and Ruby for your application
-2. Running a daemon process such as [pgbouncer](https://github.com/heroku/heroku-buildpack-pgbouncer) with your application
-3. Pulling in system dependencies.
+Common use cases are:
+
+1. Running multiple language buildpacks in sequence, such as Node.js for asset preparation using NPM libraries followed by the native buildpack of your application;
+1. Launching a daemon process such as [pgbouncer](https://github.com/heroku/heroku-buildpack-pgbouncer) before your application starts;
+1. Pulling in system-level dependencies before the main buildpack processes your application.
 
 ## Usage
 
-You **do not have to use this buildpack directly** on Heroku. Instead, the `heroku buildpacks:add` command allows you to add multiple buildpacks to your application. This list of buildpacks is then properly visible through the API and command line, and you do not have to maintain a proprietary `.buildpacks` file.
+You **do not have to use this buildpack directly** on Heroku.
 
-For example, to have the Node.js buildpack run first, followed by the Ruby buildpack, run the following commands on your application:
+The `heroku buildpacks:add` command allows you to add multiple buildpacks to your application. This list of buildpacks is then properly visible through the API and command line, and you do not have to maintain a proprietary `.buildpacks` file.
+
+For example, to have the Node.js buildpack run first, followed by the PHP buildpack (which during a build uses Node.js tools to e.g. prepare assets), run the following commands on your application:
 
     $ heroku buildpacks:add https://github.com/heroku/heroku-buildpack-nodejs.git
-    $ heroku buildpacks:add https://github.com/heroku/heroku-buildpack-ruby.git
+    $ heroku buildpacks:add https://github.com/heroku/heroku-buildpack-php.git
 
 Run `heroku help buildpacks` for a full list of commands available to manage buildpacks.
-
-### Usage of a fork
-
-If you have forked this buildpack to customize its behavior, you need to manually instruct Heroku to use your fork, and create a `.buildpacks` file with the list of buildpacks to run.
-
-First, set your fork as the buildpack for your app:
-
-    $ heroku buildpacks:set https://github.com/yourusername/heroku-buildpack-multi.git
-
-Next, will need to create a `.buildpacks` file which contains the list of buildpacks (in the desired order) you wish to be run when you deploy:
-
-    $ cat .buildpacks
-    https://github.com/heroku/heroku-buildpack-nodejs.git
-    https://github.com/heroku/heroku-buildpack-ruby.git
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Heroku buildpack: multi
 
-This buildpack has been deprecated, as the associated functionality exists natively on the Heroku platform. Please refer to https://devcenter.heroku.com/articles/buildpacks for documentation.
+This buildpack has been deprecated, as the associated functionality exists natively on the Heroku platform. Please refer to https://devcenter.heroku.com/articles/buildpacks and https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app for documentation.
 
 Common use cases are:
 

--- a/README.md
+++ b/README.md
@@ -9,15 +9,28 @@ allows one to multiple other buildpacks in a single deploy process. This helps s
 
 ## Usage
 
-To use this buildpack you'll first need to set it as your custom buildpack:
+You **do not have to use this buildpack directly** on Heroku. Instead, the `heroku buildpacks:add` command allows you to add multiple buildpacks to your application. This list of buildpacks is then properly visible through the API and command line, and you do not have to maintain a proprietary `.buildpacks` file.
 
-    $ heroku buildpacks:set https://github.com/heroku/heroku-buildpack-multi.git
+For example, to have the Node.js buildpack run first, followed by the Ruby buildpack, run the following commands on your application:
 
-From here you will need to create a `.buildpacks` file which contains (in order) the buildpacks you wish to run when you deploy:
+    $ heroku buildpacks:add https://github.com/heroku/heroku-buildpack-nodejs.git
+    $ heroku buildpacks:add https://github.com/heroku/heroku-buildpack-ruby.git
+
+Run `heroku help buildpacks` for a full list of commands available to manage buildpacks.
+
+### Usage of a fork
+
+If you have forked this buildpack to customize its behavior, you need to manually instruct Heroku to use your fork, and create a `.buildpacks` file with the list of buildpacks to run.
+
+First, set your fork as the buildpack for your app:
+
+    $ heroku buildpacks:set https://github.com/yourusername/heroku-buildpack-multi.git
+
+Next, will need to create a `.buildpacks` file which contains the list of buildpacks (in the desired order) you wish to be run when you deploy:
 
     $ cat .buildpacks
-    https://github.com/heroku/heroku-buildpack-nodejs.git#0198c71daa8
-    https://github.com/heroku/heroku-buildpack-ruby.git#v86
+    https://github.com/heroku/heroku-buildpack-nodejs.git
+    https://github.com/heroku/heroku-buildpack-ruby.git
 
 ## License
 

--- a/bin/compile
+++ b/bin/compile
@@ -4,6 +4,15 @@ set -e
 
 unset GIT_DIR
 
+echo ""
+echo " !     WARNING"
+echo "       This buildpack (heroku/heroku-buildpack-multi) is deprecated, as"
+echo "       the functionality now exists natively on the Heroku platform."
+echo "       Please upgrade to the new feature at your earliest convenience."
+echo "       Run 'heroku help buildpacks' for more information, or refer to"
+echo "       Dev Center: https://devcenter.heroku.com/articles/buildpacks."
+echo ""
+
 for BUILDPACK in $(cat $1/.buildpacks); do
   dir=$(mktemp -t buildpackXXXXX)
   rm -rf $dir

--- a/bin/compile
+++ b/bin/compile
@@ -2,14 +2,6 @@
 
 set -e
 
-function indent() {
-  c='s/^/       /'
-  case $(uname) in
-    Darwin) sed -l "$c";;
-    *)      sed -u "$c";;
-  esac
-}
-
 unset GIT_DIR
 
 for BUILDPACK in $(cat $1/.buildpacks); do


### PR DESCRIPTION
That way the list of buildpacks gets exposed through the API, so it's easily visible to customers, support etc.
