### PR TITLE
The in-band warning is a disruption to customers who rely on this buildpack.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,15 +4,6 @@ set -e
 
 unset GIT_DIR
 
-echo ""
-echo " !     WARNING"
-echo "       This buildpack (heroku/heroku-buildpack-multi) is deprecated, as"
-echo "       the functionality now exists natively on the Heroku platform."
-echo "       Please upgrade to the new feature at your earliest convenience."
-echo "       Run 'heroku help buildpacks' for more information, or refer to"
-echo "       Dev Center: https://devcenter.heroku.com/articles/buildpacks."
-echo ""
-
 for BUILDPACK in $(cat $1/.buildpacks); do
   dir=$(mktemp -t buildpackXXXXX)
   rm -rf $dir


### PR DESCRIPTION
For most people, we want them not to use this. If someone's actually thought this through, they don't need to be reminded every build. Since we can't do a message on first build only, remove the message.