### PR TITLE
Soften "deprecation" messaging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Heroku buildpack: multi
 
-This buildpack has been deprecated, as the associated functionality exists natively on the Heroku platform. Please refer to https://devcenter.heroku.com/articles/buildpacks and https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app for documentation.
+This buildpack is no longer actively maintained. The associated functionality exists natively on the Heroku platform. Please refer to https://devcenter.heroku.com/articles/buildpacks and https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app for documentation.
 
 Common use cases are:
 


### PR DESCRIPTION
There is no roadmap to taking `heroku-buildpack-multi` away from its users, or
for any feature changes that would break it. Our public stance (and, in fact,
our internal stance) is that work on checked-in definitions of buildpack lists
will not happen in this repo, and that this buildpack is "finished."