### PR TITLE
Removing set -e

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
-
 unset GIT_DIR
 
 for BUILDPACK in $(cat $1/.buildpacks); do


### PR DESCRIPTION
This is causing the buildpack to swallow error messages because it automatically exits with 1 instead of echoing the error message.