### PR TITLE
Revert "Use --depth=1 to speed up git clones of large repositories"

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -22,13 +22,13 @@ for BUILDPACK in $(cat $1/.buildpacks); do
       mkdir -p "$dir"
       curl -s "$url" | tar xvz -C "$dir" >/dev/null 2>&1
     else
-      if [ "$branch" != "" ]; then
-        git clone --branch=$branch --depth=1 $url $dir >/dev/null 2>&1
-      else
-        git clone --depth=1 $url $dir >/dev/null 2>&1
-      fi
+      git clone $url $dir >/dev/null 2>&1
     fi
     cd $dir
+
+    if [ "$branch" != "" ]; then
+      git checkout $branch >/dev/null 2>&1
+    fi
 
     # we'll get errors later if these are needed and don't exist
     chmod -f +x $dir/bin/{detect,compile,release} || true


### PR DESCRIPTION
Reverts heroku/heroku-buildpack-multi#17, since whilst `--branch` supports branches and tags, it does not support arbitrary git refs such as used when pinning to a specific SHA.