### PR TITLE
`cd` back to original directory for the buildpack to work

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -29,6 +29,8 @@ for BUILDPACK in $(cat $1/.buildpacks); do
     if [ "$branch" != "" ]; then
       git checkout $branch >/dev/null 2>&1
     fi
+    # change back to original directory for the sake of the configured buildpacks
+    cd -
 
     # we'll get errors later if these are needed and don't exist
     chmod -f +x $dir/bin/{detect,compile,release} || true


### PR DESCRIPTION
Some underlying buildpacks expect the current directory to be that of the app and not the `/tmp/buildpackXYZ` directory that this changes into. This fixes that.