### PR TITLE
Revert "`cd` back to original directory for the buildpack to work"

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -29,8 +29,6 @@ for BUILDPACK in $(cat $1/.buildpacks); do
     if [ "$branch" != "" ]; then
       git checkout $branch >/dev/null 2>&1
     fi
-    # change back to original directory for the sake of the configured buildpacks
-    cd -
 
     # we'll get errors later if these are needed and don't exist
     chmod -f +x $dir/bin/{detect,compile,release} || true


### PR DESCRIPTION
Reverts heroku/heroku-buildpack-multi#20 since it deviates from the working directory used for non-multi builds, and can cause breakage such as that seen in:
https://heroku.support/966104