### PR TITLE
feat: add xtrace support

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -2,6 +2,8 @@
 
 set -e
 
+[ "$BUILDPACK_XTRACE" ] && set -o xtrace
+
 unset GIT_DIR
 
 for BUILDPACK in $(cat $1/.buildpacks); do


### PR DESCRIPTION
The python buildpack supports something similar: https://github.com/heroku/heroku-buildpack-python/blob/f3abce6ac660a009c7ffac95d5b86d231555c28a/bin/compile#L22